### PR TITLE
chore: switch wrangler connection status to properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 npm-debug.log
 .DS_Store
 .fuse_hidden*
+.idea

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -21,7 +21,7 @@ var sourceFiles = [
 ];
 
 var lintFiles = [
-  'gulpfile.js',
+  'gulpfile.js'
   // Karma configuration
   // 'karma-*.conf.js'
 ].concat(sourceFiles);

--- a/karma-dist-concatenated.conf.js
+++ b/karma-dist-concatenated.conf.js
@@ -70,4 +70,4 @@ module.exports = function(config) {
     // how many browser should be started simultaneous
     concurrency: Infinity
   })
-}
+};

--- a/karma-dist-minified.conf.js
+++ b/karma-dist-minified.conf.js
@@ -70,4 +70,4 @@ module.exports = function(config) {
     // how many browser should be started simultaneous
     concurrency: Infinity
   })
-}
+};

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -71,4 +71,4 @@ module.exports = function(config) {
     // how many browser should be started simultaneous
     concurrency: Infinity
   })
-}
+};

--- a/src/services/actionCableSocketWrangler.js
+++ b/src/services/actionCableSocketWrangler.js
@@ -56,15 +56,6 @@ ngActionCable.factory("ActionCableSocketWrangler", function($rootScope, ActionCa
   };
   websocket.on_connection_open_callback= connection_alive;
   var methods= {
-    connected: function(){
-      return (_live && !_connecting);
-    },
-    connecting: function(){
-      return (_live && !!_connecting);
-    },
-    disconnected: function(){
-      return !_live;
-    },
     start: function(){
       if (ActionCableConfig.debug) console.info("Live STARTED");
       _live= true;
@@ -79,6 +70,25 @@ ngActionCable.factory("ActionCableSocketWrangler", function($rootScope, ActionCa
       websocket.close();
     }
   };
+
+  Object.defineProperties(methods, {
+    connected: {
+      get: function () {
+        return (_live && !_connecting);
+      }
+    },
+    connecting: {
+      get: function () {
+        return (_live && !!_connecting);
+      }
+    },
+    disconnected: {
+      get: function(){
+        return !_live;
+      }
+    }
+  });
+
   if (ActionCableConfig.autoStart) methods.start();
   return methods;
 });

--- a/test/unit/services/actionCableSocketWrangler.spec.js
+++ b/test/unit/services/actionCableSocketWrangler.spec.js
@@ -1,12 +1,112 @@
 'use strict';
 
 describe('ActionCableSocketWrangler', function(){
-  var ActionCableSocketWrangler;
+  var ActionCableSocketWrangler,
+      ActionCableWebsocket,
+      resetWebsocketMock;
+
+  resetWebsocketMock = function () {
+    ActionCableWebsocket = {
+      attempt_restart: function() {},
+      on_connection_close_callback: function() {},
+      on_connection_open_callback: function() {},
+      close: function() {}
+    };
+  };
+
   beforeEach(module('ngActionCable'));
+
+  beforeEach(function() {
+    resetWebsocketMock();
+    module(function($provide) { $provide.value('ActionCableWebsocket', ActionCableWebsocket); });
+    module(function($provide) { $provide.value('ActionCableConfig', { autoStart: false }); });
+  });
+
   beforeEach(inject(function(_ActionCableSocketWrangler_) {
     ActionCableSocketWrangler= _ActionCableSocketWrangler_;
   }));
-  it('exists', function(){
-    expect(ActionCableSocketWrangler).toBeObject;
+
+  afterEach(function() {
+    resetWebsocketMock();
+  });
+
+  describe('connected', function() {
+    it('initiates to false', function(){
+      expect(ActionCableSocketWrangler.connected).toBe(false);
+    });
+
+    describe('when starts with connection call back', function() {
+      beforeEach(function() {
+        ActionCableWebsocket.attempt_restart = function() {
+          this.on_connection_open_callback();
+        };
+        ActionCableSocketWrangler.start();
+      });
+
+      it('returns true', function(){
+        expect(ActionCableSocketWrangler.connected).toBe(true);
+      });
+    });
+
+    describe('when starts without connection call back', function() {
+      beforeEach(function() {
+        ActionCableWebsocket.attempt_restart = function() {};
+        ActionCableSocketWrangler.start();
+      });
+
+      it('returns false', function(){
+        expect(ActionCableSocketWrangler.connected).toBe(false);
+      });
+    })
+  });
+
+  describe('connecting', function() {
+    it('initiates to false', function(){
+      expect(ActionCableSocketWrangler.connecting).toBe(false);
+    });
+
+    describe('when starts without connection call back', function() {
+      beforeEach(function() {
+        ActionCableWebsocket.attempt_restart = function() {};
+        ActionCableSocketWrangler.start();
+      });
+
+      it('returns true', function(){
+        expect(ActionCableSocketWrangler.connecting).toBe(true);
+      });
+    })
+  });
+
+  describe('disconnected', function() {
+    it('initiates to true', function(){
+      expect(ActionCableSocketWrangler.disconnected).toBe(true);
+    });
+
+    describe('when starts with connection call back', function() {
+      beforeEach(function() {
+        ActionCableWebsocket.attempt_restart = function() {
+          this.on_connection_open_callback();
+        };
+        ActionCableSocketWrangler.start();
+      });
+
+      it('returns false', function(){
+        expect(ActionCableSocketWrangler.disconnected).toBe(false);
+      });
+    });
+
+    describe('when starts with connection call back and stop', function() {
+      beforeEach(function() {
+        ActionCableWebsocket.attempt_restart = function() {
+          this.on_connection_open_callback();
+        };
+        ActionCableSocketWrangler.start();
+        ActionCableSocketWrangler.stop();
+      });
+
+      it('returns true', function(){
+        expect(ActionCableSocketWrangler.disconnected).toBe(true);
+      });
+    })
   });
 });


### PR DESCRIPTION
https://github.com/angular-actioncable/angular-actioncable/issues/19
- switched from
```
ActionCableSocketWrangler.connected()
ActionCableSocketWrangler.connecting()
ActionCableSocketWrangler.disconnected()
```
to
```
ActionCableSocketWrangler.connected
ActionCableSocketWrangler.connecting
ActionCableSocketWrangler.disconnected
```