### PR TITLE
Allow for ws options to be passed through ACC

### DIFF
--- a/src/services/actionCableConfig.js
+++ b/src/services/actionCableConfig.js
@@ -8,7 +8,8 @@ ngActionCable.factory('ActionCableConfig', function() {
   var _wsUri;
   var config= {
     autoStart: true,
-    debug: false
+    debug: false,
+    wsOptions: {}
   };
   Object.defineProperty(config, 'wsUri', {
     get: function () {

--- a/src/services/actionCableWebsocket.js
+++ b/src/services/actionCableWebsocket.js
@@ -27,6 +27,7 @@
 
 ngActionCable.factory("ActionCableWebsocket", ['$websocket', 'ActionCableController', 'ActionCableConfig', function($websocket, ActionCableController, ActionCableConfig) {
   var wsUrl = ActionCableConfig.wsUri;
+  var wsOptions = ActionCableConfig.wsOptions;
   var controller = ActionCableController;
   var dataStream = null;
   var methods;
@@ -66,7 +67,7 @@ ngActionCable.factory("ActionCableWebsocket", ['$websocket', 'ActionCableControl
   };
   var new_data_stream = function(){
     if(dataStream === null) {
-      dataStream = $websocket(wsUrl);
+      dataStream = $websocket(wsUrl, null, null, wsOptions);
       dataStream.onClose(function(arg){
         close_connection();
         connected = false;


### PR DESCRIPTION
ActionCableConfig can now be used to pass
low-level ws configuration options. This is,
of course, if the PR I made to the underlying
angular-websocket project gets accepted.

No breaking changes were introduced by this commit.
